### PR TITLE
Remove consensus specific conversion types

### DIFF
--- a/cachescale/interface.go
+++ b/cachescale/interface.go
@@ -1,9 +1,5 @@
 package cachescale
 
-import (
-	"github.com/0xsoniclabs/consensus/inter/idx"
-)
-
 type Func interface {
 	I(int) int
 	I32(int32) int32
@@ -13,7 +9,4 @@ type Func interface {
 	U64(uint64) uint64
 	F32(float32) float32
 	F64(float64) float64
-	Events(v idx.Event) idx.Event
-	Blocks(v idx.Block) idx.Block
-	Frames(v idx.Frame) idx.Frame
 }

--- a/cachescale/ratio.go
+++ b/cachescale/ratio.go
@@ -10,10 +10,6 @@
 
 package cachescale
 
-import (
-	"github.com/0xsoniclabs/consensus/inter/idx"
-)
-
 // Ratio alters the cache sizes proportionally to a ratio
 type Ratio struct {
 	Base   uint64
@@ -59,16 +55,4 @@ func (r Ratio) I32(v int32) int32 {
 
 func (r Ratio) I64(v int64) int64 {
 	return int64(r.U64(uint64(v)))
-}
-
-func (r Ratio) Events(v idx.Event) idx.Event {
-	return idx.Event(r.U64(uint64(v)))
-}
-
-func (r Ratio) Blocks(v idx.Block) idx.Block {
-	return idx.Block(r.U64(uint64(v)))
-}
-
-func (r Ratio) Frames(v idx.Frame) idx.Frame {
-	return idx.Frame(r.U64(uint64(v)))
 }

--- a/cachescale/ratio_test.go
+++ b/cachescale/ratio_test.go
@@ -2,8 +2,6 @@ package cachescale
 
 import (
 	"testing"
-
-	"github.com/0xsoniclabs/consensus/inter/idx"
 )
 
 func TestRatio_U64(t *testing.T) {
@@ -114,32 +112,5 @@ func TestRatio_I64(t *testing.T) {
 	want := int64(4) // (3*4)/3 = 4
 	if got := r.I64(v); got != want {
 		t.Errorf("I64() = %v, want %v", got, want)
-	}
-}
-
-func TestRatio_Events(t *testing.T) {
-	r := Ratio{Base: 2, Target: 3}
-	v := idx.Event(3)
-	want := idx.Event(5) // (3*3)/2 = 4.5 → 5
-	if got := r.Events(v); got != want {
-		t.Errorf("Events() = %v, want %v", got, want)
-	}
-}
-
-func TestRatio_Blocks(t *testing.T) {
-	r := Ratio{Base: 3, Target: 1}
-	v := idx.Block(9)
-	want := idx.Block(3) // (9*1)/3 = 3
-	if got := r.Blocks(v); got != want {
-		t.Errorf("Blocks() = %v, want %v", got, want)
-	}
-}
-
-func TestRatio_Frames(t *testing.T) {
-	r := Ratio{Base: 4, Target: 5}
-	v := idx.Frame(8)
-	want := idx.Frame(10) // (8*5)/4 = 10
-	if got := r.Frames(v); got != want {
-		t.Errorf("Frames() = %v, want %v", got, want)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.22.0
 toolchain go1.23.6
 
 require (
-	github.com/0xsoniclabs/consensus v0.0.0-20250303105940-38ab29a1723f
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/stretchr/testify v1.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/0xsoniclabs/consensus v0.0.0-20250303105940-38ab29a1723f h1:ebqdkgYeve7/QPQdFyKJc5k1MTfsvyXY8HwVBUX3VYA=
-github.com/0xsoniclabs/consensus v0.0.0-20250303105940-38ab29a1723f/go.mod h1:iqY4OlMSIpNvXZ0e7FiPsMJFcjPfem2VYmsYyluLr14=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=

--- a/wlru/wlru.go
+++ b/wlru/wlru.go
@@ -3,7 +3,7 @@ package wlru
 import (
 	"sync"
 
-	"github.com/0xsoniclabs/consensus/utils/simplewlru"
+	"github.com/0xsoniclabs/cacheutils/simplewlru"
 )
 
 // Cache is a thread-safe fixed size LRU cache.


### PR DESCRIPTION
This PR removes cache scaling functions which depend on Consensus types. This will require changes to `consensus/Metric` structure and consequently minor changes in the client itself.  